### PR TITLE
avoiding 'window is not defined' error in outside of browser context

### DIFF
--- a/src/utils/Raf.js
+++ b/src/utils/Raf.js
@@ -1,4 +1,8 @@
 (function() {
+  if (typeof window === 'undefined') {
+    return
+  }
+
   let lastTime = 0;
   let vendors = ['ms', 'moz', 'webkit', 'o'];
   for (let x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {


### PR DESCRIPTION
#10 